### PR TITLE
Make horse entity ID unique

### DIFF
--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/entityreplacements/ArmorStandReplacement.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/entityreplacements/ArmorStandReplacement.java
@@ -33,7 +33,6 @@ public class ArmorStandReplacement implements EntityReplacement {
 	private float yaw, pitch;
 	private float headYaw;
 	private boolean small = false;
-	private static int ENTITY_ID = Integer.MAX_VALUE - 16000;
 
 	private enum State {
 		HOLOGRAM, ZOMBIE;
@@ -228,7 +227,7 @@ public class ArmorStandReplacement implements EntityReplacement {
 			updateMetadata();
 			updateLocation();
 		} else if (currentState==State.HOLOGRAM) {
-			int[] entityIds = new int[] {entityId, ENTITY_ID--};
+			int[] entityIds = new int[] {entityId, entityId*10000};
 
 			PacketWrapper spawnSkull = new PacketWrapper(0x0E, null, user);
 			spawnSkull.write(Type.VAR_INT, entityIds[0]);


### PR DESCRIPTION
This fixes an issue with HolographicDisplays v2.2.6 on a 1.8.8 TacoSpigot server where the horse metadata packet gets sent for the WitherSkull entity causing a client-side crash on 1.7 clients. I'm not sure exactly what causes this to happen but changing the entity ID for the horse seemed to fix it on my server.

The line at which the crash stems from is [here](https://github.com/f7h2938h3/ViaRewind/blob/9dedad4947a27f340e8a116afcb98a06dcfdca1f/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/entityreplacements/ArmorStandReplacement.java#L195), for 1.7 clients the index of `10` for WitherSkull metadata should be a byte setting whether or not the skull is invulnerable, and the crash happens when the client reads that and receives a String rather than a byte. By changing the entity ID of the horse entity to something unique this issue is mitigated.

The stacktrace for the crash that occurs is below
```
Description: Ticking entity

java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Byte
	at net.minecraft.entity.DataWatcher.func_75683_a(SourceFile:83)
	at net.minecraft.entity.projectile.EntityWitherSkull.func_82342_d(SourceFile:103)
	at net.minecraft.entity.projectile.EntityWitherSkull.func_82341_c(SourceFile:33)
	at net.minecraft.entity.projectile.EntityFireball.func_70071_h_(SourceFile:165)
	at net.minecraft.world.World.func_72866_a(World.java:2070)
	at net.minecraft.world.World.func_72870_g(World.java:2034)
	at net.minecraft.world.World.func_72939_s(World.java:1887)
	at net.minecraft.client.Minecraft.func_71407_l(Minecraft.java:2006)
	at net.minecraft.client.Minecraft.func_71411_J(Minecraft.java:973)
	at net.minecraft.client.Minecraft.func_99999_d(Minecraft.java:898)
	at net.minecraft.client.main.Main.main(SourceFile:148)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
	at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
	at java.lang.reflect.Method.invoke(Unknown Source)
	at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:196)
	at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:231)
	at org.multimc.EntryPoint.listen(EntryPoint.java:143)
	at org.multimc.EntryPoint.main(EntryPoint.java:34)


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Stacktrace:
	at net.minecraft.entity.DataWatcher.func_75683_a(SourceFile:83)
	at net.minecraft.entity.projectile.EntityWitherSkull.func_82342_d(SourceFile:103)
	at net.minecraft.entity.projectile.EntityWitherSkull.func_82341_c(SourceFile:33)
	at net.minecraft.entity.projectile.EntityFireball.func_70071_h_(SourceFile:165)
	at net.minecraft.world.World.func_72866_a(World.java:2070)
	at net.minecraft.world.World.func_72870_g(World.java:2034)

-- Entity being ticked --
Details:
	Entity Type: WitherSkull (net.minecraft.entity.projectile.EntityWitherSkull)
	Entity ID: 85265
	Entity Name: entity.WitherSkull.name
	Entity's Exact location: -59.53, 113.48, -56.50
	Entity's Block location: World: (-60,113,-57), Chunk: (at 4,7,7 in -4,-4; contains blocks -64,0,-64 to -49,255,-49), Region: (-1,-1; contains chunks -32,-32 to -1,-1, blocks -512,0,-512 to -1,255,-1)
	Entity's Momentum: 0.00, 0.00, 0.00
Stacktrace:
	at net.minecraft.world.World.func_72939_s(World.java:1887)
```