### PR TITLE
Don't create several threads per user

### DIFF
--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/storage/WorldBorder.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/storage/WorldBorder.java
@@ -17,24 +17,19 @@ public class WorldBorder extends StoredObject {
 	private int portalTeleportBoundary;
 	private int warningTime, warningBlocks;
 	private boolean init = false;
-	private final TaskId taskId;
 
 	private final int VIEW_DISTANCE = 16;
 
 	public WorldBorder(UserConnection user) {
 		super(user);
-		taskId = Via.getPlatform().runRepeatingSync(new Runnable() {
-			@Override
-			public void run() {
-				if (!getUser().getChannel().isOpen()) {
-					Via.getPlatform().cancelTask(taskId);
-					return;
-				}
-				if (!isInit()) return;
+	}
 
-				sendPackets();
-			}
-		}, 2L);
+	public void tick() {
+		if (!isInit()) {
+			return;
+		}
+
+		sendPackets();
 	}
 
 	private enum Side {

--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/storage/WorldBorder.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_7_6_10to1_8/storage/WorldBorder.java
@@ -1,6 +1,7 @@
 package de.gerrygames.viarewind.protocol.protocol1_7_6_10to1_8.storage;
 
 import de.gerrygames.viarewind.protocol.protocol1_7_6_10to1_8.Protocol1_7_6_10TO1_8;
+import de.gerrygames.viarewind.protocol.protocol1_8to1_9.Tickable;
 import de.gerrygames.viarewind.utils.PacketUtil;
 import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.Via;
@@ -9,7 +10,7 @@ import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.platform.TaskId;
 import us.myles.ViaVersion.api.type.Type;
 
-public class WorldBorder extends StoredObject {
+public class WorldBorder extends StoredObject implements Tickable {
 	private double x, z;
 	private double oldDiameter, newDiameter;
 	private long lerpTime;
@@ -24,6 +25,7 @@ public class WorldBorder extends StoredObject {
 		super(user);
 	}
 
+	@Override
 	public void tick() {
 		if (!isInit()) {
 			return;

--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/Protocol1_8TO1_9.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/Protocol1_8TO1_9.java
@@ -70,20 +70,10 @@ public class Protocol1_8TO1_9 extends Protocol {
 				iter.remove();
 			}
 
-			Cooldown cd = user.get(Cooldown.class);
-			if (cd != null) {
-			    cd.tick();
-            }
-
-            Levitation ls = user.get(Levitation.class);
-            if (ls != null) {
-                ls.tick();
-            }
-
-            WorldBorder wb = user.get(WorldBorder.class);
-            if (wb != null) {
-                wb.tick();
-            }
+            user.getStoredObjects().values().stream()
+                    .filter(Tickable.class::isInstance)
+                    .map(Tickable.class::cast)
+                    .forEach(Tickable::tick);
 		}
 	};
 

--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/Protocol1_8TO1_9.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/Protocol1_8TO1_9.java
@@ -2,17 +2,13 @@ package de.gerrygames.viarewind.protocol.protocol1_8to1_9;
 
 import com.google.common.collect.Sets;
 import de.gerrygames.viarewind.ViaRewind;
-import de.gerrygames.viarewind.protocol.protocol1_7_6_10to1_8.storage.WorldBorder;
+import de.gerrygames.viarewind.protocol.protocol1_8to1_9.chunks.ChunkPacketTransformer;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.entityreplacement.ShulkerBulletReplacement;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.entityreplacement.ShulkerReplacement;
-import de.gerrygames.viarewind.protocol.protocol1_8to1_9.sound.Effect;
-import de.gerrygames.viarewind.protocol.protocol1_8to1_9.types.Chunk1_8Type;
-import de.gerrygames.viarewind.replacement.EntityReplacement;
-import de.gerrygames.viarewind.storage.BlockState;
-import de.gerrygames.viarewind.protocol.protocol1_8to1_9.chunks.ChunkPacketTransformer;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.items.ItemRewriter;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.items.ReplacementRegistry1_8to1_9;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.metadata.MetadataRewriter;
+import de.gerrygames.viarewind.protocol.protocol1_8to1_9.sound.Effect;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.sound.SoundRemapper;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.storage.BlockPlaceDestroyTracker;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.storage.BossBarStorage;
@@ -21,6 +17,9 @@ import de.gerrygames.viarewind.protocol.protocol1_8to1_9.storage.EntityTracker;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.storage.Levitation;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.storage.PlayerPosition;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.storage.Windows;
+import de.gerrygames.viarewind.protocol.protocol1_8to1_9.types.Chunk1_8Type;
+import de.gerrygames.viarewind.replacement.EntityReplacement;
+import de.gerrygames.viarewind.storage.BlockState;
 import de.gerrygames.viarewind.utils.ChatUtil;
 import de.gerrygames.viarewind.utils.PacketUtil;
 import us.myles.ViaVersion.api.PacketWrapper;
@@ -50,9 +49,8 @@ import us.myles.viaversion.libs.opennbt.tag.builtin.StringTag;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -63,18 +61,15 @@ public class Protocol1_8TO1_9 extends Protocol {
 
 	private static final Consumer<Collection<UserConnection>> TICKER =
             users -> {
-		Iterator<UserConnection> iter = users.iterator();
-		while (iter.hasNext()) {
-			UserConnection user = iter.next();
-			if (!user.getChannel().isOpen()) {
-				iter.remove();
-			}
+		users.removeIf(u -> !u.getChannel().isOpen());
 
-            user.getStoredObjects().values().stream()
-                    .filter(Tickable.class::isInstance)
-                    .map(Tickable.class::cast)
-                    .forEach(Tickable::tick);
-		}
+		users.stream()
+                .map(UserConnection::getStoredObjects)
+                .map(Map::values)
+                .flatMap(Collection::stream)
+                .filter(Tickable.class::isInstance)
+                .map(Tickable.class::cast)
+                .forEach(Tickable::tick);
 	};
 
 	public Protocol1_8TO1_9() {

--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/storage/Cooldown.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/storage/Cooldown.java
@@ -3,6 +3,7 @@ package de.gerrygames.viarewind.protocol.protocol1_8to1_9.storage;
 import de.gerrygames.viarewind.ViaRewind;
 import de.gerrygames.viarewind.api.ViaRewindConfig;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.Protocol1_8TO1_9;
+import de.gerrygames.viarewind.protocol.protocol1_8to1_9.Tickable;
 import de.gerrygames.viarewind.utils.PacketUtil;
 import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.Pair;
@@ -15,7 +16,7 @@ import us.myles.ViaVersion.api.type.Type;
 import java.util.ArrayList;
 import java.util.UUID;
 
-public class Cooldown extends StoredObject {
+public class Cooldown extends StoredObject implements Tickable {
 
 	private double attackSpeed = 4.0;
 	private long lastHit = 0;
@@ -31,6 +32,7 @@ public class Cooldown extends StoredObject {
 		if (cooldownIndicator==ViaRewindConfig.CooldownIndicator.DISABLED) return;
 	}
 
+	@Override
 	public void tick() {
 		if (!hasCooldown()) {
 			if (lastSend) {

--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/storage/Levitation.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/storage/Levitation.java
@@ -11,30 +11,24 @@ import us.myles.ViaVersion.api.type.Type;
 
 public class Levitation extends StoredObject {
 	private int amplifier;
-	private boolean active = false;
-	final TaskId taskId;
+	private volatile boolean active = false;
 
 	public Levitation(UserConnection user) {
 		super(user);
-		taskId = Via.getPlatform().runRepeatingSync(new Runnable() {
-			@Override
-			public void run() {
-				if (!user.getChannel().isOpen()) {
-					Via.getPlatform().cancelTask(taskId);
-					return;
-				}
-				if (!active) {
-					return;
-				}
-				int vY = (amplifier+1) * 360;
-				PacketWrapper packet = new PacketWrapper(0x12, null, Levitation.this.getUser());
-				packet.write(Type.VAR_INT, getUser().get(EntityTracker.class).getPlayerId());
-				packet.write(Type.SHORT, (short)0);
-				packet.write(Type.SHORT, (short)vY);
-				packet.write(Type.SHORT, (short)0);
-				PacketUtil.sendPacket(packet, Protocol1_8TO1_9.class);
-			}
-		}, 1L);
+	}
+
+	public void tick() {
+		if (!active) {
+			return;
+		}
+
+		int vY = (amplifier+1) * 360;
+		PacketWrapper packet = new PacketWrapper(0x12, null, Levitation.this.getUser());
+		packet.write(Type.VAR_INT, getUser().get(EntityTracker.class).getPlayerId());
+		packet.write(Type.SHORT, (short)0);
+		packet.write(Type.SHORT, (short)vY);
+		packet.write(Type.SHORT, (short)0);
+		PacketUtil.sendPacket(packet, Protocol1_8TO1_9.class);
 	}
 
 	public void setActive(boolean active) {

--- a/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/storage/Levitation.java
+++ b/core/src/main/java/de/gerrygames/viarewind/protocol/protocol1_8to1_9/storage/Levitation.java
@@ -1,6 +1,8 @@
 package de.gerrygames.viarewind.protocol.protocol1_8to1_9.storage;
 
+import com.google.common.base.Ticker;
 import de.gerrygames.viarewind.protocol.protocol1_8to1_9.Protocol1_8TO1_9;
+import de.gerrygames.viarewind.protocol.protocol1_8to1_9.Tickable;
 import de.gerrygames.viarewind.utils.PacketUtil;
 import us.myles.ViaVersion.api.PacketWrapper;
 import us.myles.ViaVersion.api.Via;
@@ -9,7 +11,7 @@ import us.myles.ViaVersion.api.data.UserConnection;
 import us.myles.ViaVersion.api.platform.TaskId;
 import us.myles.ViaVersion.api.type.Type;
 
-public class Levitation extends StoredObject {
+public class Levitation extends StoredObject implements Tickable {
 	private int amplifier;
 	private volatile boolean active = false;
 
@@ -17,6 +19,7 @@ public class Levitation extends StoredObject {
 		super(user);
 	}
 
+	@Override
 	public void tick() {
 		if (!active) {
 			return;


### PR DESCRIPTION
Levitation, cooldown, and world border all create a repeating task per user. This leads to several threads being created and kept as long as each user is online on Bungeecord instances. Creating even one thread per user can absolutely tank performance, especially in high density instances. Having multiple threads per user further exacerbates performance issues. This rewrite fixes that by reusing one repeating task for each type of task.

This rewrite isn't super clean, as it was done quickly to address an issue in production, but it's clean enough and drastically reduces performance hit of ViaRewind. 