### PR TITLE
BossBar Wither Fixes 1.9 -> 1.8

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/data/WitherBossBar.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/data/WitherBossBar.java
@@ -201,7 +201,7 @@ public class WitherBossBar implements BossBar {
 		entityData.add(new EntityData(0, EntityDataTypes1_8.BYTE, (byte) 0x20));
 		entityData.add(new EntityData(2, EntityDataTypes1_8.STRING, title));
 		entityData.add(new EntityData(3, EntityDataTypes1_8.BYTE, (byte) 1));
-		entityData.add(new EntityData(6, EntityDataTypes1_8.FLOAT, health * 300f));
+		entityData.add(new EntityData(6, EntityDataTypes1_8.FLOAT, Math.max(health * 300f, 1f))); // the wither will just die if the health is too low
         entityData.add(new EntityData(20, EntityDataTypes1_8.INT, 880));
 
 		addMob.write(Types.ENTITY_DATA_LIST1_8, entityData);


### PR DESCRIPTION
Adds metadata to the spawn packet to make the wither extremely small so the player doesn't see a wither outline when the bossbar is on low health aswell as stops the wither from dying if it has 0 "health" aka the bossbar isnt filled atall