### PR TITLE
Mitigate security vulnerabilities in CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,14 @@
 version: 2
 updates:
   - package-ecosystem: "gradle"
+    cooldown:
+      default-days: 7
     directory: "/"
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 7
     directory: "/"
     schedule:
       interval: "weekly"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,21 +1,30 @@
 name: Build
-on: [ pull_request, push, workflow_dispatch ]
+on: [pull_request, push, workflow_dispatch]
+permissions:
+  contents: read
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    # Only run on PRs if the source branch is on a different repo. We do not need to run everything twice.
+    if: ${{ github.event_name != 'pull_request' || github.repository != github.event.pull_request.head.repo.full_name }}
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
         with:
           persist-credentials: false
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # 5.0.0
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # 5.0.0
         with:
           distribution: 'temurin'
           java-version: 17
           check-latest: true
       - name: Build with Gradle
         run: ./gradlew build
+      - name: Upload Artifacts to GitHub
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # 5.0.0
+        with:
+          name: Artifacts
+          path: build/libs/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - master
       - dev
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   publish:
@@ -11,18 +15,18 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # 6.0.0
         with:
           persist-credentials: false
       - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # 5.0.0
       - name: Set up JDK 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165 # 5.0.0
         with:
           distribution: 'temurin'
           java-version: 17
           check-latest: true
-      - name: Build
+      - name: Build with Gradle
         run: ./gradlew build
       - name: Publish to Hangar
         env:


### PR DESCRIPTION
Ditto of [this PR](https://github.com/ViaVersion/ViaVersion/pull/4725) except the "Do not run everything twice" rule is synced over for the build workflow and that `update-gradle-wrapper` is skipped as it does not exist here.