### PR TITLE
Change dependabot schedule's interval to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
       default-days: 7
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
   - package-ecosystem: "github-actions"
     cooldown:
       default-days: 7
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"


### PR DESCRIPTION
Addresses kennytv's feedback where potentional update spam can happen from specific subversions when dependabot PRs.