### PR TITLE
Only set hologram state if nametag is visible

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/data/VirtualHologramEntity.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/data/VirtualHologramEntity.java
@@ -120,7 +120,7 @@ public class VirtualHologramEntity {
         gravity = (armorStandFlags & 0x02) == 0;
 
         State prevState = currentState;
-        if (invisible && name != null) {
+        if (invisible && name != null && alwaysShowNametag == 1) {
             currentState = State.HOLOGRAM;
         } else if (gravity) {
             currentState = State.ZOMBIE;


### PR DESCRIPTION
It's better to keep armor stands in the ZOMBIE state when they don't display text as this allows for clickable armor stands on 1.7.10
The fake entities used in armorstand state don't allow to be clickable due to their bounding box being "hacked".