### PR TITLE
Fix holograms

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/data/VirtualHologramEntity.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/data/VirtualHologramEntity.java
@@ -46,6 +46,8 @@ public class VirtualHologramEntity {
     private String name = null;
     private float yaw, pitch;
     private float headYaw;
+    private byte flags = 0;
+    private byte armorStandFlags = 0;
     private boolean small = false;
     private boolean marker = false;
     private boolean sneaking = false;
@@ -99,8 +101,6 @@ public class VirtualHologramEntity {
         }
 
         // Filter armor stand data to calculate emulation
-        byte flags = 0;
-        byte armorStandFlags = 0;
         for (EntityData entityData : entityDataTracker) {
             if (entityData.id() == 0 && entityData.dataType() == EntityDataTypes1_8.BYTE) {
                 flags = ((Number) entityData.getValue()).byteValue();

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/data/VirtualHologramEntity.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/data/VirtualHologramEntity.java
@@ -167,6 +167,18 @@ public class VirtualHologramEntity {
             } else {
                 return baseOffset + (0.9875 * 2);
             }
+        } else if (currentState == State.ZOMBIE_NO_GRAVITY) {
+            // 1.7 ride stack offset sum: Squid (0.95 * 0.75) + Zombie (1.8 * 0.75) = 2.0625
+            // By starting at -2.0625, we zero out the 1.7 passenger height so we can apply 1.8's offsets.
+            double baseOffset = -2.0625;
+
+            if (marker) {
+                // 1.8 Marker ArmorStand height is 0.0 -> mounted offset 0.0
+                return baseOffset;
+            } else {
+                // 1.8 Normal ArmorStand height is 1.975 -> mounted offset 1.975 * 0.75 = 1.48125
+                return baseOffset + 1.48125;
+            }
         } else {
             return -0.4;
         }

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/data/VirtualHologramEntity.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/data/VirtualHologramEntity.java
@@ -24,6 +24,7 @@ import com.viaversion.viarewind.api.type.RewindTypes;
 import com.viaversion.viarewind.protocol.v1_7_6_10to1_7_2_5.packet.ClientboundPackets1_7_2_5;
 import com.viaversion.viarewind.protocol.v1_8to1_7_6_10.Protocol1_8To1_7_6_10;
 import com.viaversion.viarewind.protocol.v1_8to1_7_6_10.rewriter.EntityPacketRewriter1_8;
+import com.viaversion.viarewind.protocol.v1_8to1_7_6_10.storage.EntityTracker1_8;
 import com.viaversion.viaversion.api.connection.UserConnection;
 import com.viaversion.viaversion.api.minecraft.entities.EntityTypes1_8;
 import com.viaversion.viaversion.api.minecraft.entitydata.EntityData;
@@ -303,6 +304,13 @@ public class VirtualHologramEntity {
             this.entityIds = entityIds;
         }
 
+        for (int extraId : entityIds) {
+            if (extraId != entityId) {
+                ((EntityTracker1_8) user.getEntityTracker(Protocol1_8To1_7_6_10.class)).setExtraHologramId(entityId, extraId);
+            }
+        }
+
+
         sendEntityDataUpdate(entityRewriter);
         if (entityIds == null) {
             return;
@@ -338,6 +346,13 @@ public class VirtualHologramEntity {
         if (entityIds == null) {
             return;
         }
+
+        for (int extraId : entityIds) {
+            if (extraId != entityId) {
+                ((EntityTracker1_8) user.getEntityTracker(Protocol1_8To1_7_6_10.class)).removeExtraHologramId(extraId);
+            }
+        }
+
         final PacketWrapper despawn = PacketWrapper.create(ClientboundPackets1_7_2_5.REMOVE_ENTITIES, user);
         despawn.write(Types.BYTE, (byte) entityIds.length);
         for (int id : entityIds) {

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/rewriter/PlayerPacketRewriter1_8.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/rewriter/PlayerPacketRewriter1_8.java
@@ -532,13 +532,15 @@ public class PlayerPacketRewriter1_8 extends RewriterBase<Protocol1_8To1_7_6_10>
                     if (mode != 0) {
                         return;
                     }
-                    final int entityId = wrapper.get(Types.VAR_INT, 0);
                     final EntityTracker1_8 tracker = wrapper.user().getEntityTracker(Protocol1_8To1_7_6_10.class);
+                    final int entityId = tracker.getHologramIdWithExtra(wrapper.get(Types.VAR_INT, 0));
                     final PlayerSessionStorage position = wrapper.user().get(PlayerSessionStorage.class);
 
-                    if (!tracker.getHolograms().containsKey(entityId)) {
+                    if (entityId == -1) {
                         return;
                     }
+
+                    wrapper.set(Types.VAR_INT, 0, entityId);
                     final AABB boundingBox = tracker.getHolograms().get(entityId).getBoundingBox();
 
                     Vector3d pos = new Vector3d(position.getPosX(), position.getPosY() + 1.8, position.getPosZ());

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/storage/EntityTracker1_8.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/storage/EntityTracker1_8.java
@@ -46,6 +46,7 @@ import java.util.logging.Level;
 public class EntityTracker1_8 extends EntityTrackerBase {
 
     private final Int2ObjectMap<VirtualHologramEntity> holograms = new Int2ObjectArrayMap<>();
+    private final Int2IntMap extraHologramIds = new Int2IntArrayMap();
     private final Int2IntMap vehicles = new Int2IntArrayMap();
     private final Int2ObjectMap<UUID> entityIdToUUID = new Int2ObjectArrayMap<>();
     private final Object2IntMap<UUID> entityUUIDToId = new Object2IntOpenHashMap<>();
@@ -88,6 +89,8 @@ public class EntityTracker1_8 extends EntityTrackerBase {
     @Override
     public void clearEntities() {
         super.clearEntities();
+        holograms.clear();
+        extraHologramIds.clear();
         vehicles.clear();
     }
 
@@ -187,6 +190,21 @@ public class EntityTracker1_8 extends EntityTrackerBase {
 
     public Int2ObjectMap<VirtualHologramEntity> getHolograms() {
         return holograms;
+    }
+
+    public void setExtraHologramId(final int entityId, final int extraId) {
+        extraHologramIds.put(extraId, entityId);
+    }
+
+    public void removeExtraHologramId(int extraId) {
+        extraHologramIds.remove(extraId);
+    }
+
+    public int getHologramIdWithExtra(final int id) {
+        if (holograms.containsKey(id)) {
+            return id;
+        }
+        return extraHologramIds.getOrDefault(id, -1);
     }
 
     public boolean isSpectator() {


### PR DESCRIPTION
Fixes 2 things:
- Entity metadata is now saved. The issue was that if a new entity data packet is send without the flags being changed the state isn't correctly calculated.
- Zombie no gravity now has a more correct offset (fix on top of https://github.com/ViaVersion/ViaRewind/pull/609)
- Interactions on 1.7 are improved by also accounting for "extra" entity ids (the riding entity) as an interactable entity 
