### PR TITLE
Fix brewing stand titles for 1.8 clients on 1.9+ servers

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/WindowTracker.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/WindowTracker.java
@@ -52,11 +52,11 @@ public class WindowTracker extends StoredObject {
         openWindow.write(Types.UNSIGNED_BYTE, windowId);
         openWindow.write(Types.STRING, "minecraft:brewing_stand");
 
-        TextComponent title = new StringComponent().
-            append(new TranslationComponent("container.brewing")).
-            append(new StringComponent(": " + TextFormatting.DARK_GRAY)).
-            append(new StringComponent(amount + " " + TextFormatting.DARK_RED)).
-            append(new TranslationComponent("item.blazePowder.name", TextFormatting.DARK_RED));
+        TextComponent title = new StringComponent()
+            .append(new TranslationComponent("container.brewing"))
+            .append(new StringComponent(": ").formatted(TextFormatting.DARK_GRAY))
+            .append(new StringComponent(amount + " ").formatted(TextFormatting.DARK_RED))
+            .append(new TranslationComponent("item.blazePowder.name").formatted(TextFormatting.DARK_RED));
 
         openWindow.write(Types.COMPONENT, TextComponentSerializer.V1_8.serializeJson(title));
         openWindow.write(Types.UNSIGNED_BYTE, (short) 420);


### PR DESCRIPTION
`WindowTracker.updateBrewingStand` concatenated `TextFormatting` enums into strings (invoking the enum's debug `toString()` instead of `§`+code) and passed `TextFormatting.DARK_RED` as a `TranslationComponent`. This caused a bug where 1.8 clients would fall back to displaying the raw JSON object as the window title.
                                                                                                                                                              
Fixed by using `TextComponent.formatted(TextFormatting)` on each part of the brewing stand title construction.

\- NotAlexNoyle
[TrueOG Network](https://github.com/true-og/true-og)