### PR TITLE
Rewrite "no face" in digging packet to a valid 1.8 value

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/rewriter/PlayerPacketRewriter1_8.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/rewriter/PlayerPacketRewriter1_8.java
@@ -608,6 +608,16 @@ public class PlayerPacketRewriter1_8 extends RewriterBase<Protocol1_8To1_7_6_10>
             protected void register() {
                 map(Types.VAR_INT); // Status
                 map(RewindTypes.U_BYTE_POSITION, Types.BLOCK_POSITION1_8); // Position
+                handler(wrapper -> {
+                    // 1.7 uses 255 as "no face"
+                    // 1.8 changed this to only be in the range EnumFacing range (0-5) and uses DOWN when no face is used
+                    // This properly rewrites invalid values to the 1.8 equivalent
+                    int face = wrapper.read(Types.UNSIGNED_BYTE);
+                    if (face > 5) {
+                        face = 0;
+                    }
+                    wrapper.write(Types.UNSIGNED_BYTE, (short) face);
+                });
             }
         });
 


### PR DESCRIPTION
A correct fix for the issue that was being experienced in https://github.com/ViaVersion/ViaRewind/pull/629
This pr ensures the facing value is never an invalid value and always in the range 1.8 servers accept (0-5)
<img width="918" height="223" alt="image" src="https://github.com/user-attachments/assets/8ce16174-6379-4e4c-b5bf-9b146bd32ffc" />

MC 1.7.10: (uses 255)
<img width="989" height="155" alt="image" src="https://github.com/user-attachments/assets/56a9f2ab-4632-406f-9c6a-40283e09ec0b" />

MC 1.8.9: (uses EnumFacing.DOWN equivalent with 0)
<img width="1312" height="152" alt="image" src="https://github.com/user-attachments/assets/2f4499b6-ed1e-494b-8236-b5a11935bb1a" />
