### PR TITLE
fix: nametag visibility duplicate names edge case

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/rewriter/PlayerPacketRewriter1_8.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/rewriter/PlayerPacketRewriter1_8.java
@@ -511,7 +511,13 @@ public class PlayerPacketRewriter1_8 extends RewriterBase<Protocol1_8To1_7_6_10>
                 String username = message.split(" ")[1];
                 final GameProfileStorage storage = wrapper.user().get(GameProfileStorage.class);
 
-                final GameProfileStorage.GameProfile profile = storage.get(username, true);
+                // Multiple players with the same name may exist. This will only represent
+                // fake players so it's fine to just pick the first one.
+                List<GameProfileStorage.GameProfile> profiles = storage.get(username, true);
+                if (profiles.isEmpty()) {
+                    return;
+                }
+                final GameProfileStorage.GameProfile profile = profiles.get(0);
                 if (profile != null && profile.uuid != null) {
                     wrapper.cancel();
 

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/storage/EntityTracker1_8.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/storage/EntityTracker1_8.java
@@ -222,17 +222,16 @@ public class EntityTracker1_8 extends EntityTrackerBase {
 
     public void checkNametagVisbility(final String username) {
         final GameProfileStorage profileStorage = user().get(GameProfileStorage.class);
-        final GameProfileStorage.GameProfile profile = profileStorage.get(username, false);
-        if (profile == null) {
-            return;
-        }
+        final List<GameProfileStorage.GameProfile> profiles = profileStorage.get(username, false);
 
-        final int entityId = getPlayerEntityId(profile.uuid);
-        if (entityId == -1) {
-            return;
-        }
+        for (GameProfileStorage.GameProfile profile : profiles) {
+            final int entityId = getPlayerEntityId(profile.uuid);
+            if (entityId == -1) {
+                return;
+            }
 
-        checkNametagVisibility(entityId);
+            checkNametagVisibility(entityId);
+        }
     }
 
     private boolean isPlayerNametagHidden(final int entityId) {

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/storage/GameProfileStorage.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/storage/GameProfileStorage.java
@@ -17,6 +17,10 @@
  */
 package com.viaversion.viarewind.protocol.v1_8to1_7_6_10.storage;
 
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ListMultimap;
+import com.google.common.collect.Multimap;
 import com.viaversion.nbt.tag.CompoundTag;
 import com.viaversion.nbt.tag.ListTag;
 import com.viaversion.nbt.tag.StringTag;
@@ -34,6 +38,7 @@ import java.util.UUID;
 
 public class GameProfileStorage extends StoredObject {
     private final Map<UUID, GameProfile> properties = new HashMap<>();
+    private final ListMultimap<String, GameProfile> nameToProfile = ArrayListMultimap.create();
 
     public GameProfileStorage(UserConnection user) {
         super(user);
@@ -42,6 +47,7 @@ public class GameProfileStorage extends StoredObject {
     public GameProfile put(UUID uuid, String name, String displayName, int ping, int gamemode) {
         GameProfile gameProfile = new GameProfile(uuid, name, displayName, ping, gamemode);
         properties.put(uuid, gameProfile);
+        nameToProfile.put(name, gameProfile);
         return gameProfile;
     }
 
@@ -49,19 +55,9 @@ public class GameProfileStorage extends StoredObject {
         return properties.get(uuid);
     }
 
-    public GameProfile get(String name, boolean ignoreCase) {
+    public List<GameProfile> get(String name, boolean ignoreCase) {
         if (ignoreCase) name = name.toLowerCase();
-
-        for (GameProfile profile : properties.values()) {
-            if (profile.name == null) continue;
-
-            String n = ignoreCase ? profile.name.toLowerCase() : profile.name;
-
-            if (n.equals(name)) {
-                return profile;
-            }
-        }
-        return null;
+        return nameToProfile.get(name);
     }
 
     public List<GameProfile> getAllWithPrefix(String prefix, boolean ignoreCase) {
@@ -81,7 +77,9 @@ public class GameProfileStorage extends StoredObject {
     }
 
     public GameProfile remove(UUID uuid) {
-        return properties.remove(uuid);
+        GameProfile removedProfile = properties.remove(uuid);
+        nameToProfile.get(removedProfile.name).remove(removedProfile);
+        return removedProfile;
     }
 
 


### PR DESCRIPTION
Fixes an edge case where the nametag invisibility is only applied to one player when multiple players with the same name exist. This extends support for plugins spawning fake players with identical names.