### PR TITLE
Don't forward in-flight velocity updates for arrows or fireballs

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/EntityPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/EntityPacketRewriter1_9.java
@@ -83,13 +83,15 @@ public class EntityPacketRewriter1_9 extends VREntityRewriter<ClientboundPackets
             wrapper.write(Types.ENTITY_DATA_LIST1_8, entityData);
         });
 
-        // 1.8 tracks arrows with sendVelocity=false, so the client predicts the trajectory locally from the
-        // spawn velocity. Modern servers send periodic arrow velocity (trackDeltas) that overwrites this
-        // prediction and desyncs the client's block-collision raytrace. Drop in-flight velocity to match 1.8.
+        // 1.8 tracks arrows and fireballs with sendVelocity=false (EntityTracker: EntityArrow/EntityFireball ->
+        // (.., false)), so the client predicts their trajectory locally from the spawn velocity. Modern servers send
+        // periodic velocity (trackDeltas) that overwrites this prediction and desyncs the client's block-collision
+        // raytrace (arrows visibly stick to / slide off block edges). Drop in-flight velocity for them to match 1.8.
         protocol.registerClientbound(ClientboundPackets1_9.SET_ENTITY_MOTION, wrapper -> {
             final int entityId = wrapper.passthrough(Types.VAR_INT);
             final EntityType type = wrapper.user().getEntityTracker(Protocol1_9To1_8.class).entityType(entityId);
-            if (type != null && type.isOrHasParent(EntityTypes1_9.EntityType.ARROW)) {
+            if (type != null && (type.isOrHasParent(EntityTypes1_9.EntityType.ARROW)
+                    || type.isOrHasParent(EntityTypes1_9.EntityType.HURTING_PROJECTILE))) {
                 wrapper.cancel();
             }
         });

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/EntityPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/EntityPacketRewriter1_9.java
@@ -83,6 +83,17 @@ public class EntityPacketRewriter1_9 extends VREntityRewriter<ClientboundPackets
             wrapper.write(Types.ENTITY_DATA_LIST1_8, entityData);
         });
 
+        // 1.8 tracks arrows with sendVelocity=false, so the client predicts the trajectory locally from the
+        // spawn velocity. Modern servers send periodic arrow velocity (trackDeltas) that overwrites this
+        // prediction and desyncs the client's block-collision raytrace. Drop in-flight velocity to match 1.8.
+        protocol.registerClientbound(ClientboundPackets1_9.SET_ENTITY_MOTION, wrapper -> {
+            final int entityId = wrapper.passthrough(Types.VAR_INT);
+            final EntityType type = wrapper.user().getEntityTracker(Protocol1_9To1_8.class).entityType(entityId);
+            if (type != null && type.isOrHasParent(EntityTypes1_9.EntityType.ARROW)) {
+                wrapper.cancel();
+            }
+        });
+
         protocol.registerClientbound(ClientboundPackets1_9.ADD_ENTITY, new PacketHandlers() {
             @Override
             public void register() {


### PR DESCRIPTION
1.8 tracks arrows & fireballs with sendVelocity=false — the client predicts the whole trajectory from the spawn velocity and receives no in-flight velocity updates. Modern servers track arrow velocity deltas (trackDeltas) and send periodic velocity packets, which ViaRewind forwarded unchanged. They overwrite the client's local prediction and desync its block-collision raytrace, making arrows visibly stick to / slide off block edges before snapping back. This drops in-flight velocity packets for arrows so the client predicts cleanly, matching native 1.8.