### PR TITLE
Fix global tasks erroring

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/task/WorldBorderUpdateTask.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_8to1_7_6_10/task/WorldBorderUpdateTask.java
@@ -35,6 +35,9 @@ public class WorldBorderUpdateTask implements Runnable {
     public void run() {
         for (UserConnection connection : Via.getManager().getConnectionManager().getConnections()) {
             final WorldBorderEmulator worldBorderEmulatorTracker = connection.get(WorldBorderEmulator.class);
+            if (worldBorderEmulatorTracker == null) {
+                continue;
+            }
             if (!worldBorderEmulatorTracker.isInit()) continue;
 
             final PlayerSessionStorage playerSession = connection.get(PlayerSessionStorage.class);

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/task/CooldownIndicatorTask.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/task/CooldownIndicatorTask.java
@@ -26,7 +26,11 @@ public class CooldownIndicatorTask implements Runnable {
     @Override
     public void run() {
         for (UserConnection connection : Via.getManager().getConnectionManager().getConnections()) {
-            connection.get(CooldownStorage.class).tick(connection);
+            final CooldownStorage cooldown = connection.get(CooldownStorage.class);
+            if (cooldown == null) {
+                continue;
+            }
+            cooldown.tick(connection);
         }
     }
 }

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/task/LevitationUpdateTask.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/task/LevitationUpdateTask.java
@@ -36,6 +36,9 @@ public class LevitationUpdateTask implements Runnable {
         }
         for (UserConnection connection : Via.getManager().getConnectionManager().getConnections()) {
             final LevitationStorage levitation = connection.get(LevitationStorage.class);
+            if (levitation == null) {
+                continue;
+            }
             if (!levitation.isActive()) {
                 continue;
             }


### PR DESCRIPTION
ViaRewind assumes every connection has these storage objects even though its possible they don't have it (for example someone playing on a more modern version)

Fixes https://github.com/ViaVersion/ViaRewind/issues/564
Fixes https://github.com/ViaVersion/ViaRewind/issues/680