### PR TITLE
Update BlockItemPacketRewriter1_9.java

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/BlockItemPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/BlockItemPacketRewriter1_9.java
@@ -116,6 +116,21 @@ public class BlockItemPacketRewriter1_9 extends VRBlockItemRewriter<ClientboundP
             final Item item = wrapper.passthrough(Types.ITEM1_8);
 
             handleItemToClient(wrapper.user(), item);
+            if (windowId == -2) {
+                // 1.8 has no window -2 (set player-inventory slot directly); remap to window 0 with the menu slot.
+                final int windowSlot;
+                if (slot >= 0 && slot <= 8) windowSlot = slot + 36;
+                else if (slot >= 36 && slot <= 39) windowSlot = 44 - slot;
+                else if (slot == 40) windowSlot = 45;
+                else windowSlot = slot;
+                if (windowSlot == 45) {
+                    wrapper.cancel();
+                    return;
+                }
+                wrapper.set(Types.BYTE, 0, (byte) 0);
+                wrapper.set(Types.SHORT, 0, (short) windowSlot);
+                return;
+            }
             if (windowId == 0 && slot == 45) {
                 wrapper.cancel();
                 return;

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/BlockItemPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/BlockItemPacketRewriter1_9.java
@@ -79,8 +79,14 @@ public class BlockItemPacketRewriter1_9 extends VRBlockItemRewriter<ClientboundP
         protocol.registerClientbound(ClientboundPackets1_9.OPEN_SCREEN, wrapper -> {
             final short windowId = wrapper.passthrough(Types.UNSIGNED_BYTE);
             final String windowType = wrapper.passthrough(Types.STRING);
+            wrapper.passthrough(Types.COMPONENT); // title
+            final short slotCount = wrapper.passthrough(Types.UNSIGNED_BYTE);
 
-            wrapper.user().get(WindowTracker.class).put(windowId, windowType);
+            final WindowTracker tracker = wrapper.user().get(WindowTracker.class);
+            tracker.put(windowId, windowType);
+            // 1.8 brewing has no fuel slot; ViaRewind drops it, so the client sees one fewer.
+            final boolean brewing = windowType.equalsIgnoreCase("minecraft:brewing_stand");
+            tracker.openWindow(windowId, brewing ? slotCount - 1 : slotCount);
         });
 
         protocol.registerClientbound(ClientboundPackets1_9.CONTAINER_SET_CONTENT, wrapper -> {
@@ -117,13 +123,29 @@ public class BlockItemPacketRewriter1_9 extends VRBlockItemRewriter<ClientboundP
 
             handleItemToClient(wrapper.user(), item);
             if (windowId == -2) {
-                // 1.8 has no window -2 (set player-inventory slot directly); remap to window 0 with the menu slot.
+                // 1.8 has no window -2 (set a player-inv slot by raw index, ignoring the open container) — retarget it.
+                final WindowTracker tracker = wrapper.user().get(WindowTracker.class);
+                final short openWindow = tracker.openWindowId();
+                if (openWindow != 0) {
+                    // Foreign container open: 1.8 only applies player-inv changes through it (main=size.., hotbar=size+27..).
+                    final int size = tracker.openWindowSize();
+                    final int containerSlot;
+                    if (slot >= 0 && slot <= 8) containerSlot = size + 27 + slot;
+                    else if (slot >= 9 && slot <= 35) containerSlot = size + slot - 9;
+                    else { // armor/offhand: no slot in a foreign container
+                        wrapper.cancel();
+                        return;
+                    }
+                    wrapper.set(Types.BYTE, 0, (byte) openWindow);
+                    wrapper.set(Types.SHORT, 0, (short) containerSlot);
+                    return;
+                }
+                // Otherwise window 0 with the menu slot.
                 final int windowSlot;
                 if (slot >= 0 && slot <= 8) windowSlot = slot + 36;
+                else if (slot >= 9 && slot <= 35) windowSlot = slot;
                 else if (slot >= 36 && slot <= 39) windowSlot = 44 - slot;
-                else if (slot == 40) windowSlot = 45;
-                else windowSlot = slot;
-                if (windowSlot == 45) {
+                else { // offhand/body/saddle: no 1.8 equivalent
                     wrapper.cancel();
                     return;
                 }

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/BlockItemPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/BlockItemPacketRewriter1_9.java
@@ -84,9 +84,7 @@ public class BlockItemPacketRewriter1_9 extends VRBlockItemRewriter<ClientboundP
 
             final WindowTracker tracker = wrapper.user().get(WindowTracker.class);
             tracker.put(windowId, windowType);
-            // 1.8 brewing has no fuel slot; ViaRewind drops it, so the client sees one fewer.
-            final boolean brewing = windowType.equalsIgnoreCase("minecraft:brewing_stand");
-            tracker.openWindow(windowId, brewing ? slotCount - 1 : slotCount);
+            tracker.openWindow(windowId, clientInventorySize(windowType, slotCount));
         });
 
         protocol.registerClientbound(ClientboundPackets1_9.CONTAINER_SET_CONTENT, wrapper -> {
@@ -227,6 +225,22 @@ public class BlockItemPacketRewriter1_9 extends VRBlockItemRewriter<ClientboundP
         enchantmentRewriter = new LegacyEnchantmentRewriter(nbtTagName());
         enchantmentRewriter.registerEnchantment(9, "§7Frost Walker");
         enchantmentRewriter.registerEnchantment(70, "§7Mending");
+    }
+
+    static int clientInventorySize(String windowType, int packetSlotCount) {
+        // The client only uses the packet's slot count when constructing dynamic inventories.
+        // Fixed menus construct their own slots; use the translated 1.8 layout for those.
+        return switch (windowType) {
+            case "minecraft:furnace", "minecraft:villager", "minecraft:anvil" -> 3;
+            case "minecraft:brewing_stand" -> 4;
+            case "minecraft:beacon" -> 1;
+            case "minecraft:dispenser", "minecraft:dropper" -> 9;
+            case "minecraft:enchanting_table" -> 2;
+            case "minecraft:crafting_table" -> 10;
+            case "minecraft:hopper" -> packetSlotCount;
+            case "EntityHorse" -> packetSlotCount > 2 ? 17 : 2;
+            default -> packetSlotCount / 9 * 9;
+        };
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/BlockItemPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/BlockItemPacketRewriter1_9.java
@@ -84,7 +84,7 @@ public class BlockItemPacketRewriter1_9 extends VRBlockItemRewriter<ClientboundP
 
             final WindowTracker tracker = wrapper.user().get(WindowTracker.class);
             tracker.put(windowId, windowType);
-            tracker.openWindow(windowId, clientInventorySize(windowType, slotCount));
+            tracker.openWindow(windowId, windowType, slotCount);
         });
 
         protocol.registerClientbound(ClientboundPackets1_9.CONTAINER_SET_CONTENT, wrapper -> {
@@ -128,9 +128,11 @@ public class BlockItemPacketRewriter1_9 extends VRBlockItemRewriter<ClientboundP
                     // Foreign container open: 1.8 only applies player-inv changes through it (main=size.., hotbar=size+27..).
                     final int size = tracker.openWindowSize();
                     final int containerSlot;
-                    if (slot >= 0 && slot <= 8) containerSlot = size + 27 + slot;
-                    else if (slot >= 9 && slot <= 35) containerSlot = size + slot - 9;
-                    else { // armor/offhand: no slot in a foreign container
+                    if (slot >= 0 && slot <= 8) {
+                        containerSlot = size + 27 + slot;
+                    } else if (slot >= 9 && slot <= 35) {
+                        containerSlot = size + slot - 9;
+                    } else { // armor/offhand: no slot in a foreign container
                         wrapper.cancel();
                         return;
                     }
@@ -138,12 +140,16 @@ public class BlockItemPacketRewriter1_9 extends VRBlockItemRewriter<ClientboundP
                     wrapper.set(Types.SHORT, 0, (short) containerSlot);
                     return;
                 }
+
                 // Otherwise window 0 with the menu slot.
                 final int windowSlot;
-                if (slot >= 0 && slot <= 8) windowSlot = slot + 36;
-                else if (slot >= 9 && slot <= 35) windowSlot = slot;
-                else if (slot >= 36 && slot <= 39) windowSlot = 44 - slot;
-                else { // offhand/body/saddle: no 1.8 equivalent
+                if (slot >= 0 && slot <= 8) {
+                    windowSlot = slot + 36;
+                } else if (slot >= 9 && slot <= 35) {
+                    windowSlot = slot;
+                } else if (slot >= 36 && slot <= 39) {
+                    windowSlot = 44 - slot;
+                } else { // offhand/body/saddle: no 1.8 equivalent
                     wrapper.cancel();
                     return;
                 }
@@ -151,10 +157,12 @@ public class BlockItemPacketRewriter1_9 extends VRBlockItemRewriter<ClientboundP
                 wrapper.set(Types.SHORT, 0, (short) windowSlot);
                 return;
             }
+
             if (windowId == 0 && slot == 45) {
                 wrapper.cancel();
                 return;
             }
+
             final WindowTracker windowTracker = wrapper.user().get(WindowTracker.class);
             final String windowType = windowTracker.get(windowId);
             if (windowType != null && windowType.equalsIgnoreCase("minecraft:brewing_stand")) {
@@ -225,22 +233,6 @@ public class BlockItemPacketRewriter1_9 extends VRBlockItemRewriter<ClientboundP
         enchantmentRewriter = new LegacyEnchantmentRewriter(nbtTagName());
         enchantmentRewriter.registerEnchantment(9, "§7Frost Walker");
         enchantmentRewriter.registerEnchantment(70, "§7Mending");
-    }
-
-    static int clientInventorySize(String windowType, int packetSlotCount) {
-        // The client only uses the packet's slot count when constructing dynamic inventories.
-        // Fixed menus construct their own slots; use the translated 1.8 layout for those.
-        return switch (windowType) {
-            case "minecraft:furnace", "minecraft:villager", "minecraft:anvil" -> 3;
-            case "minecraft:brewing_stand" -> 4;
-            case "minecraft:beacon" -> 1;
-            case "minecraft:dispenser", "minecraft:dropper" -> 9;
-            case "minecraft:enchanting_table" -> 2;
-            case "minecraft:crafting_table" -> 10;
-            case "minecraft:hopper" -> packetSlotCount;
-            case "EntityHorse" -> packetSlotCount > 2 ? 17 : 2;
-            default -> packetSlotCount / 9 * 9;
-        };
     }
 
     @Override

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/WindowTracker.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/WindowTracker.java
@@ -38,6 +38,9 @@ public class WindowTracker extends StoredObject {
     private final HashMap<Short, Item[]> brewingItems = new HashMap<>();
     private final Map<Short, Short> enchantmentProperties = new HashMap<>();
 
+    private short openWindowId = 0; // 0 = none open
+    private int openWindowSize = 0; // open window's container slots, excluding the player inventory
+
     public WindowTracker(UserConnection user) {
         super(user);
     }
@@ -83,6 +86,23 @@ public class WindowTracker extends StoredObject {
     public void remove(short windowId) {
         types.remove(windowId);
         brewingItems.remove(windowId);
+        if (windowId == openWindowId) {
+            openWindowId = 0;
+            openWindowSize = 0;
+        }
+    }
+
+    public void openWindow(short windowId, int slotCount) {
+        openWindowId = windowId;
+        openWindowSize = slotCount;
+    }
+
+    public short openWindowId() {
+        return openWindowId;
+    }
+
+    public int openWindowSize() {
+        return openWindowSize;
     }
 
     public Item[] getBrewingItems(short windowId) {

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/WindowTracker.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/WindowTracker.java
@@ -39,7 +39,7 @@ public class WindowTracker extends StoredObject {
     private final Map<Short, Short> enchantmentProperties = new HashMap<>();
 
     private short openWindowId = 0; // 0 = none open
-    private int openWindowSize = 0; // open window's container slots, excluding the player inventory
+    private int openWindowSize = 0; // Translated client container slots, excluding the player inventory
 
     public WindowTracker(UserConnection user) {
         super(user);

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/WindowTracker.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/WindowTracker.java
@@ -38,7 +38,7 @@ public class WindowTracker extends StoredObject {
     private final HashMap<Short, Item[]> brewingItems = new HashMap<>();
     private final Map<Short, Short> enchantmentProperties = new HashMap<>();
 
-    private short openWindowId = 0; // 0 = none open
+    private short openWindowId = 0;
     private int openWindowSize = 0; // Translated client container slots, excluding the player inventory
 
     public WindowTracker(UserConnection user) {
@@ -92,9 +92,22 @@ public class WindowTracker extends StoredObject {
         }
     }
 
-    public void openWindow(short windowId, int slotCount) {
+    public void openWindow(final short windowId, final String windowType, final int slotCount) {
         openWindowId = windowId;
-        openWindowSize = slotCount;
+
+        // The client only uses the packet's slot count when constructing dynamic inventories.
+        // Fixed menus construct their own slots; use the translated 1.8 layout for those.
+        openWindowSize = switch (windowType) {
+            case "minecraft:furnace", "minecraft:villager", "minecraft:anvil" -> 3;
+            case "minecraft:brewing_stand" -> 4;
+            case "minecraft:beacon" -> 1;
+            case "minecraft:dispenser", "minecraft:dropper" -> 9;
+            case "minecraft:enchanting_table" -> 2;
+            case "minecraft:crafting_table" -> 10;
+            case "minecraft:hopper" -> slotCount;
+            case "EntityHorse" -> slotCount > 2 ? 17 : 2;
+            default -> slotCount / 9 * 9;
+        };
     }
 
     public short openWindowId() {


### PR DESCRIPTION
Problem
1.21.2, servers can update a single player-inventory slot via ClientboundSetPlayerInventory. ViaBackwards maps that to CONTAINER_SET_SLOT with window id -2

The 1.8 client's handleSetSlot only handles window -1, 0, and the oopen container's id. No -2 case, so these updates are silently dropped. This leads to the inventory only resyncing on a full window refresh (when a player opens and closes their inventory). Any server that uses this packet for inventorry updates (AHEM Minestom, but also some edge cases in vanilla, or custom vanilla servers) have this issue.