### PR TITLE
Fix splash potions turning into drinkable potions when re-sent by the…

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/BlockItemPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/BlockItemPacketRewriter1_9.java
@@ -332,7 +332,8 @@ public class BlockItemPacketRewriter1_9 extends VRBlockItemRewriter<ClientboundP
             item.setData((short) 0);
         }
 
-        if (item.identifier() == 373 && (tag == null || !tag.contains("Potion"))) { // Potions
+        if (item.identifier() == 373) { // Potions
+            // Restore the splash id even when a Potion tag is present (e.g. items re-sent by a creative mode client)
             if (item.data() >= 16384) {
                 item.setIdentifier(438);
                 item.setData((short) (item.data() - 8192));

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/EntityPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/EntityPacketRewriter1_9.java
@@ -138,6 +138,16 @@ public class EntityPacketRewriter1_9 extends VREntityRewriter<ClientboundPackets
                         wrapper.passthrough(Types.SHORT); // Velocity x
                         wrapper.passthrough(Types.SHORT); // Velocity y
                         wrapper.passthrough(Types.SHORT); // Velocity z
+                        if (type.is(EntityTypes1_9.EntityType.POTION)) {
+                            // 1.8 clients read the potion type from the object data, but newer versions only
+                            // send it in the entity data - the next packet. Held until then, see handleEntityData
+                            wrapper.cancel();
+                            final EntityTracker1_9 entityTracker = tracker(wrapper.user());
+                            entityTracker.getPendingPotionSpawns().put(entityId, new EntityTracker1_9.PotionSpawn(
+                                wrapper.get(Types.INT, 0), wrapper.get(Types.INT, 1), wrapper.get(Types.INT, 2),
+                                wrapper.get(Types.BYTE, 1), wrapper.get(Types.BYTE, 2),
+                                wrapper.get(Types.SHORT, 0), wrapper.get(Types.SHORT, 1), wrapper.get(Types.SHORT, 2)));
+                        }
                     } else {
                         final short velocityX = wrapper.read(Types.SHORT);
                         final short velocityY = wrapper.read(Types.SHORT);
@@ -541,8 +551,40 @@ public class EntityPacketRewriter1_9 extends VREntityRewriter<ClientboundPackets
         filter().handler(this::handleEntityData);
     }
 
+    private void sendDelayedPotionSpawn(EntityDataHandlerEvent event, EntityTracker1_9 tracker, Item item) {
+        final EntityTracker1_9.PotionSpawn spawn = tracker.getPendingPotionSpawns().remove(event.entityId());
+        if (spawn == null) {
+            return;
+        }
+        final Item converted = protocol.getItemRewriter().handleItemToClient(event.user(), item);
+        short data = converted == null ? 0 : converted.data();
+        if (data <= 0) {
+            data = 16384; // Unmapped potion, at least display a splash bottle
+        }
+
+        final PacketWrapper addEntity = PacketWrapper.create(ClientboundPackets1_8.ADD_ENTITY, event.user());
+        addEntity.write(Types.VAR_INT, event.entityId());
+        addEntity.write(Types.BYTE, (byte) EntityTypes1_9.ObjectType.POTION.getId());
+        addEntity.write(Types.INT, spawn.x());
+        addEntity.write(Types.INT, spawn.y());
+        addEntity.write(Types.INT, spawn.z());
+        addEntity.write(Types.BYTE, spawn.pitch());
+        addEntity.write(Types.BYTE, spawn.yaw());
+        addEntity.write(Types.INT, (int) data);
+        addEntity.write(Types.SHORT, spawn.velocityX());
+        addEntity.write(Types.SHORT, spawn.velocityY());
+        addEntity.write(Types.SHORT, spawn.velocityZ());
+        addEntity.send(Protocol1_9To1_8.class); // Before the entity data is sent
+    }
+
     private void handleEntityData(EntityDataHandlerEvent event, EntityData entityData) {
         final EntityTracker1_9 tracker = tracker(event.user());
+        if (event.entityType() == EntityTypes1_9.EntityType.POTION && entityData.value() instanceof Item potionItem) {
+            // No 1.8 equivalent; supplies the object data of the held-back spawn. Matched by value type as the index is version dependent
+            sendDelayedPotionSpawn(event, tracker, potionItem);
+            event.cancel();
+            return;
+        }
         if (entityData.id() == EntityDataIndex1_9.ENTITY_STATUS.getIndex()) {
             tracker.getStatus().put(event.entityId(), (Byte) entityData.value());
         }

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/EntityPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/EntityPacketRewriter1_9.java
@@ -134,21 +134,24 @@ public class EntityPacketRewriter1_9 extends VREntityRewriter<ClientboundPackets
                         }
                     }
 
-                    if (data > 0) {
-                        wrapper.passthrough(Types.SHORT); // Velocity x
-                        wrapper.passthrough(Types.SHORT); // Velocity y
-                        wrapper.passthrough(Types.SHORT); // Velocity z
-                        if (type.is(EntityTypes1_9.EntityType.POTION)) {
-                            // 1.8 clients read the potion type from the object data, but newer versions only
-                            // send it in the entity data - the next packet. Held until then, see handleEntityData
-                            wrapper.cancel();
-                            final EntityTracker1_9 entityTracker = tracker(wrapper.user());
-                            entityTracker.getPendingPotionSpawns().put(entityId, new EntityTracker1_9.PotionSpawn(
-                                wrapper.get(Types.INT, 0), wrapper.get(Types.INT, 1), wrapper.get(Types.INT, 2),
-                                wrapper.get(Types.BYTE, 1), wrapper.get(Types.BYTE, 2),
-                                wrapper.get(Types.SHORT, 0), wrapper.get(Types.SHORT, 1), wrapper.get(Types.SHORT, 2)));
-                        }
-                    } else {
+                    if (type.is(EntityTypes1_9.EntityType.POTION) && data > 0) {
+                        // 1.8 clients read the potion type from the object data, but newer versions only
+                        // send it in the entity data - the next packet. Held until then, see handleEntityData
+                        wrapper.cancel();
+                        final int x = wrapper.get(Types.INT, 0);
+                        final int y = wrapper.get(Types.INT, 1);
+                        final int z = wrapper.get(Types.INT, 2);
+                        final byte pitch = wrapper.get(Types.BYTE, 1);
+                        final byte yaw = wrapper.get(Types.BYTE, 2);
+                        final short velocityX = wrapper.passthrough(Types.SHORT);
+                        final short velocityY = wrapper.passthrough(Types.SHORT);
+                        final short velocityZ = wrapper.passthrough(Types.SHORT);
+                        final EntityTracker1_9 tracker = tracker(wrapper.user());
+                        tracker.getPendingPotions().put(entityId, new EntityTracker1_9.PendingPotionEntity(x, y, z, pitch, yaw, velocityX, velocityY, velocityZ));
+                        return;
+                    }
+
+                    if (data <= 0) {
                         final short velocityX = wrapper.read(Types.SHORT);
                         final short velocityY = wrapper.read(Types.SHORT);
                         final short velocityZ = wrapper.read(Types.SHORT);
@@ -454,17 +457,17 @@ public class EntityPacketRewriter1_9 extends VREntityRewriter<ClientboundPackets
             }
         });
 
-        // Passthrough except while a potion spawn is held - then folded into it
         protocol.registerClientbound(ClientboundPackets1_9.SET_ENTITY_MOTION, wrapper -> {
             final int entityId = wrapper.passthrough(Types.VAR_INT);
             final EntityTracker1_9 tracker = tracker(wrapper.user());
-            final EntityTracker1_9.PotionSpawn pending = tracker.getPendingPotionSpawns().get(entityId);
-            if (pending == null) {
-                return;
+            final EntityTracker1_9.PendingPotionEntity pending = tracker.getPendingPotions().get(entityId);
+            if (pending != null) {
+                wrapper.cancel();
+                final short velocityX = wrapper.read(Types.SHORT);
+                final short velocityY = wrapper.read(Types.SHORT);
+                final short velocityZ = wrapper.read(Types.SHORT);
+                tracker.getPendingPotions().put(entityId, pending.withVelocity(velocityX, velocityY, velocityZ));
             }
-            tracker.getPendingPotionSpawns().put(entityId,
-                pending.withVelocity(wrapper.read(Types.SHORT), wrapper.read(Types.SHORT), wrapper.read(Types.SHORT)));
-            wrapper.cancel();
         });
 
         protocol.registerClientbound(ClientboundPackets1_9.TELEPORT_ENTITY, new PacketHandlers() {
@@ -481,14 +484,18 @@ public class EntityPacketRewriter1_9 extends VREntityRewriter<ClientboundPackets
                     final int entityId = wrapper.get(Types.VAR_INT, 0);
 
                     final EntityTracker1_9 tracker = wrapper.user().getEntityTracker(Protocol1_9To1_8.class);
-                    final EntityTracker1_9.PotionSpawn pending = tracker.getPendingPotionSpawns().get(entityId);
+                    final EntityTracker1_9.PendingPotionEntity pending = tracker.getPendingPotions().get(entityId);
                     if (pending != null) {
-                        tracker.getPendingPotionSpawns().put(entityId, pending.withPosition(
-                            wrapper.get(Types.INT, 0), wrapper.get(Types.INT, 1), wrapper.get(Types.INT, 2),
-                            wrapper.get(Types.BYTE, 1), wrapper.get(Types.BYTE, 0)));
                         wrapper.cancel();
+                        final int x = wrapper.get(Types.INT, 0);
+                        final int y = wrapper.get(Types.INT, 1);
+                        final int z = wrapper.get(Types.INT, 2);
+                        final byte yaw = wrapper.get(Types.BYTE, 0);
+                        final byte pitch = wrapper.get(Types.BYTE, 1);
+                        tracker.getPendingPotions().put(entityId, pending.withPosition(x, y, z, pitch, yaw));
                         return;
                     }
+
                     if (tracker.entityType(entityId) == EntityTypes1_9.EntityType.BOAT) {
                         byte yaw = wrapper.get(Types.BYTE, 0);
                         yaw -= 64;
@@ -572,11 +579,12 @@ public class EntityPacketRewriter1_9 extends VREntityRewriter<ClientboundPackets
         filter().handler(this::handleEntityData);
     }
 
-    private void sendDelayedPotionSpawn(EntityDataHandlerEvent event, EntityTracker1_9 tracker, Item item) {
-        final EntityTracker1_9.PotionSpawn spawn = tracker.getPendingPotionSpawns().remove(event.entityId());
+    private void sendDelayedPotionSpawn(final EntityDataHandlerEvent event, final EntityTracker1_9 tracker, final Item item) {
+        final EntityTracker1_9.PendingPotionEntity spawn = tracker.getPendingPotions().remove(event.entityId());
         if (spawn == null) {
             return;
         }
+
         final Item converted = protocol.getItemRewriter().handleItemToClient(event.user(), item);
         short data = converted == null ? 0 : converted.data();
         if (data <= 0) {
@@ -602,10 +610,11 @@ public class EntityPacketRewriter1_9 extends VREntityRewriter<ClientboundPackets
         final EntityTracker1_9 tracker = tracker(event.user());
         if (event.entityType() == EntityTypes1_9.EntityType.POTION && entityData.value() instanceof Item potionItem) {
             // No 1.8 equivalent; supplies the object data of the held-back spawn. Matched by value type as the index is version dependent
-            sendDelayedPotionSpawn(event, tracker, potionItem);
+            this.sendDelayedPotionSpawn(event, tracker, potionItem);
             event.cancel();
             return;
         }
+
         if (entityData.id() == EntityDataIndex1_9.ENTITY_STATUS.getIndex()) {
             tracker.getStatus().put(event.entityId(), (Byte) entityData.value());
         }

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/EntityPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/EntityPacketRewriter1_9.java
@@ -454,6 +454,19 @@ public class EntityPacketRewriter1_9 extends VREntityRewriter<ClientboundPackets
             }
         });
 
+        // Passthrough except while a potion spawn is held - then folded into it
+        protocol.registerClientbound(ClientboundPackets1_9.SET_ENTITY_MOTION, wrapper -> {
+            final int entityId = wrapper.passthrough(Types.VAR_INT);
+            final EntityTracker1_9 tracker = tracker(wrapper.user());
+            final EntityTracker1_9.PotionSpawn pending = tracker.getPendingPotionSpawns().get(entityId);
+            if (pending == null) {
+                return;
+            }
+            tracker.getPendingPotionSpawns().put(entityId,
+                pending.withVelocity(wrapper.read(Types.SHORT), wrapper.read(Types.SHORT), wrapper.read(Types.SHORT)));
+            wrapper.cancel();
+        });
+
         protocol.registerClientbound(ClientboundPackets1_9.TELEPORT_ENTITY, new PacketHandlers() {
             @Override
             public void register() {
@@ -468,6 +481,14 @@ public class EntityPacketRewriter1_9 extends VREntityRewriter<ClientboundPackets
                     final int entityId = wrapper.get(Types.VAR_INT, 0);
 
                     final EntityTracker1_9 tracker = wrapper.user().getEntityTracker(Protocol1_9To1_8.class);
+                    final EntityTracker1_9.PotionSpawn pending = tracker.getPendingPotionSpawns().get(entityId);
+                    if (pending != null) {
+                        tracker.getPendingPotionSpawns().put(entityId, pending.withPosition(
+                            wrapper.get(Types.INT, 0), wrapper.get(Types.INT, 1), wrapper.get(Types.INT, 2),
+                            wrapper.get(Types.BYTE, 1), wrapper.get(Types.BYTE, 0)));
+                        wrapper.cancel();
+                        return;
+                    }
                     if (tracker.entityType(entityId) == EntityTypes1_9.EntityType.BOAT) {
                         byte yaw = wrapper.get(Types.BYTE, 0);
                         yaw -= 64;

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/EntityTracker1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/EntityTracker1_9.java
@@ -96,7 +96,16 @@ public class EntityTracker1_9 extends EntityTrackerBase {
         return pendingPotionSpawns;
     }
 
-    /** Spawn packet values of a thrown potion, held until its item entity data supplies the 1.8 object data. */
+    /** Spawn packet values of a thrown potion, held until its item entity data supplies the 1.8 object data.
+     *  Motion/teleports arriving while held are folded in - the released spawn carries the latest state. */
     public record PotionSpawn(int x, int y, int z, byte pitch, byte yaw, short velocityX, short velocityY, short velocityZ) {
+
+        public PotionSpawn withPosition(int x, int y, int z, byte pitch, byte yaw) {
+            return new PotionSpawn(x, y, z, pitch, yaw, velocityX, velocityY, velocityZ);
+        }
+
+        public PotionSpawn withVelocity(short velocityX, short velocityY, short velocityZ) {
+            return new PotionSpawn(x, y, z, pitch, yaw, velocityX, velocityY, velocityZ);
+        }
     }
 }

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/EntityTracker1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/EntityTracker1_9.java
@@ -36,7 +36,7 @@ public class EntityTracker1_9 extends EntityTrackerBase {
     private final Int2ObjectMap<IntList> vehicles = new Int2ObjectOpenHashMap<>();
     private final Int2ObjectMap<Vector> offsets = new Int2ObjectOpenHashMap<>();
     private final Int2IntMap status = new Int2IntOpenHashMap();
-    private final Int2ObjectMap<PotionSpawn> pendingPotionSpawns = new Int2ObjectOpenHashMap<>();
+    private final Int2ObjectMap<PendingPotionEntity> pendingPotions = new Int2ObjectOpenHashMap<>();
 
     public EntityTracker1_9(UserConnection connection) {
         super(connection, EntityTypes1_9.EntityType.PLAYER);
@@ -47,7 +47,7 @@ public class EntityTracker1_9 extends EntityTrackerBase {
         vehicles.remove(id);
         offsets.remove(id);
         status.remove(id);
-        pendingPotionSpawns.remove(id);
+        pendingPotions.remove(id);
 
         vehicles.forEach((vehicle, passengers) -> passengers.rem(id));
         vehicles.int2ObjectEntrySet().removeIf(entry -> entry.getValue().isEmpty());
@@ -92,20 +92,20 @@ public class EntityTracker1_9 extends EntityTrackerBase {
         return status;
     }
 
-    public Int2ObjectMap<PotionSpawn> getPendingPotionSpawns() {
-        return pendingPotionSpawns;
+    public Int2ObjectMap<PendingPotionEntity> getPendingPotions() {
+        return pendingPotions;
     }
 
-    /** Spawn packet values of a thrown potion, held until its item entity data supplies the 1.8 object data.
-     *  Motion/teleports arriving while held are folded in - the released spawn carries the latest state. */
-    public record PotionSpawn(int x, int y, int z, byte pitch, byte yaw, short velocityX, short velocityY, short velocityZ) {
+    public record PendingPotionEntity(int x, int y, int z, byte pitch, byte yaw, short velocityX, short velocityY, short velocityZ) {
 
-        public PotionSpawn withPosition(int x, int y, int z, byte pitch, byte yaw) {
-            return new PotionSpawn(x, y, z, pitch, yaw, velocityX, velocityY, velocityZ);
+        public PendingPotionEntity withPosition(final int x, final int y, final int z, final byte pitch, final byte yaw) {
+            return new PendingPotionEntity(x, y, z, pitch, yaw, velocityX, velocityY, velocityZ);
         }
 
-        public PotionSpawn withVelocity(short velocityX, short velocityY, short velocityZ) {
-            return new PotionSpawn(x, y, z, pitch, yaw, velocityX, velocityY, velocityZ);
+        public PendingPotionEntity withVelocity(final short velocityX, final short velocityY, final short velocityZ) {
+            return new PendingPotionEntity(x, y, z, pitch, yaw, velocityX, velocityY, velocityZ);
         }
+
     }
+
 }

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/EntityTracker1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/EntityTracker1_9.java
@@ -36,6 +36,7 @@ public class EntityTracker1_9 extends EntityTrackerBase {
     private final Int2ObjectMap<IntList> vehicles = new Int2ObjectOpenHashMap<>();
     private final Int2ObjectMap<Vector> offsets = new Int2ObjectOpenHashMap<>();
     private final Int2IntMap status = new Int2IntOpenHashMap();
+    private final Int2ObjectMap<PotionSpawn> pendingPotionSpawns = new Int2ObjectOpenHashMap<>();
 
     public EntityTracker1_9(UserConnection connection) {
         super(connection, EntityTypes1_9.EntityType.PLAYER);
@@ -46,6 +47,7 @@ public class EntityTracker1_9 extends EntityTrackerBase {
         vehicles.remove(id);
         offsets.remove(id);
         status.remove(id);
+        pendingPotionSpawns.remove(id);
 
         vehicles.forEach((vehicle, passengers) -> passengers.rem(id));
         vehicles.int2ObjectEntrySet().removeIf(entry -> entry.getValue().isEmpty());
@@ -88,5 +90,13 @@ public class EntityTracker1_9 extends EntityTrackerBase {
 
     public Int2IntMap getStatus() {
         return status;
+    }
+
+    public Int2ObjectMap<PotionSpawn> getPendingPotionSpawns() {
+        return pendingPotionSpawns;
+    }
+
+    /** Spawn packet values of a thrown potion, held until its item entity data supplies the 1.8 object data. */
+    public record PotionSpawn(int x, int y, int z, byte pitch, byte yaw, short velocityX, short velocityY, short velocityZ) {
     }
 }


### PR DESCRIPTION
The 1.9->1.8 serverbound item conversion only restored the splash potion id (373 -> 438) when no Potion tag was present