### PR TITLE
use round instead of truncating (matches modern VecDeltaCodec + RelativeMoveUtil)

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/Protocol1_9To1_8.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/Protocol1_9To1_8.java
@@ -51,7 +51,7 @@ public class Protocol1_9To1_8 extends BackwardsProtocol<ClientboundPackets1_9, C
     public static final ValueTransformer<Double, Integer> DOUBLE_TO_INT_TIMES_32 = new ValueTransformer<>(Types.INT) {
         @Override
         public Integer transform(PacketWrapper wrapper, Double inputValue) {
-            return (int) (inputValue * 32.0D);
+            return (int) Math.round(inputValue * 32.0D);
         }
     };
     public static final ValueTransformer<Float, Byte> DEGREES_TO_ANGLE = new ValueTransformer<>(Types.BYTE) {


### PR DESCRIPTION
<img width="650" height="204" alt="image" src="https://github.com/user-attachments/assets/07637833-ee3e-4e6d-9ed5-8fad27db2c62" />

Round instead of truncating in DOUBLE_TO_INT_TIMES_32

DOUBLE_TO_INT_TIMES_32 encodes the coordinates for every absolute entity position packet using (int)(value * 32), which truncates toward zero so negative coordinates land 1/32 block closer to zero than they should. Switching to Math.round fixes that and matches the rest of the pipeline: RelativeMoveUtil already rounds the relative-move deltas, and modern MC's VecDeltaCodec does too (see ss of unobfuscated minecraft 26.1 source).