### PR TITLE
Fix use animation breaking for 1.8 viewers when status updates

### DIFF
--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/EntityPacketRewriter1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/rewriter/EntityPacketRewriter1_9.java
@@ -545,6 +545,9 @@ public class EntityPacketRewriter1_9 extends VREntityRewriter<ClientboundPackets
         final EntityTracker1_9 tracker = tracker(event.user());
         if (entityData.id() == EntityDataIndex1_9.ENTITY_STATUS.getIndex()) {
             tracker.getStatus().put(event.entityId(), (Byte) entityData.value());
+            if (tracker.isHandActive(event.entityId())) {
+                entityData.setValue((byte) ((byte) entityData.value() | 1 << STATUS_USE_BIT));
+            }
         }
         final EntityDataIndex1_9 metaIndex = EntityDataIndex1_8.searchIndex(event.entityType(), entityData.id());
         if (metaIndex == null) {
@@ -554,8 +557,10 @@ public class EntityPacketRewriter1_9 extends VREntityRewriter<ClientboundPackets
         }
         if (metaIndex.getOldType() == null || metaIndex.getNewType() == null) {
             if (metaIndex == EntityDataIndex1_9.PLAYER_HAND) { // Player eating/aiming/drinking
+                final boolean handActive = (((byte) entityData.value()) & 1 << HAND_ACTIVE_BIT) != 0;
+                tracker.setHandActive(event.entityId(), handActive);
                 byte status = (byte) tracker.getStatus().getOrDefault(event.entityId(), 0);
-                if ((((byte) entityData.value()) & 1 << HAND_ACTIVE_BIT) != 0) {
+                if (handActive) {
                     status = (byte) (status | 1 << STATUS_USE_BIT);
                 } else {
                     status = (byte) (status & ~(1 << STATUS_USE_BIT));

--- a/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/EntityTracker1_9.java
+++ b/common/src/main/java/com/viaversion/viarewind/protocol/v1_9to1_8/storage/EntityTracker1_9.java
@@ -28,6 +28,8 @@ import com.viaversion.viaversion.libs.fastutil.ints.Int2ObjectMap;
 import com.viaversion.viaversion.libs.fastutil.ints.Int2ObjectOpenHashMap;
 import com.viaversion.viaversion.libs.fastutil.ints.IntArrayList;
 import com.viaversion.viaversion.libs.fastutil.ints.IntList;
+import com.viaversion.viaversion.libs.fastutil.ints.IntOpenHashSet;
+import com.viaversion.viaversion.libs.fastutil.ints.IntSet;
 import java.util.List;
 import java.util.Map;
 
@@ -36,6 +38,7 @@ public class EntityTracker1_9 extends EntityTrackerBase {
     private final Int2ObjectMap<IntList> vehicles = new Int2ObjectOpenHashMap<>();
     private final Int2ObjectMap<Vector> offsets = new Int2ObjectOpenHashMap<>();
     private final Int2IntMap status = new Int2IntOpenHashMap();
+    private final IntSet handActive = new IntOpenHashSet();
 
     public EntityTracker1_9(UserConnection connection) {
         super(connection, EntityTypes1_9.EntityType.PLAYER);
@@ -46,6 +49,7 @@ public class EntityTracker1_9 extends EntityTrackerBase {
         vehicles.remove(id);
         offsets.remove(id);
         status.remove(id);
+        handActive.remove(id);
 
         vehicles.forEach((vehicle, passengers) -> passengers.rem(id));
         vehicles.int2ObjectEntrySet().removeIf(entry -> entry.getValue().isEmpty());
@@ -88,5 +92,17 @@ public class EntityTracker1_9 extends EntityTrackerBase {
 
     public Int2IntMap getStatus() {
         return status;
+    }
+
+    public boolean isHandActive(final int id) {
+        return handActive.contains(id);
+    }
+
+    public void setHandActive(final int id, final boolean active) {
+        if (active) {
+            handActive.add(id);
+        } else {
+            handActive.remove(id);
+        }
     }
 }


### PR DESCRIPTION
Redoing this properly from the correct branch of my fork (sorry)

Problemo

When a 1.8 client is a viewer of another player using an item (eat, drawing a bow, blocking a sword), the use animation stops when the watched player sneaks. It doesn't rrestart
until playerr restarts using the item.

## Reproduction

1. 1.8 client connects with ViaRewind to a 1.9+ server.
2. Player A starts a use item animation.
3. Player A sneaks while still using the item.
4. The animation stops on the 1.8 viewer's screen and stays gone until A stops and
   restarts the item use.

## Fix

Track hand-active per entity in `EntityTracker1_9`

Manually verified with a 1.8 client through ViaRewind (same test as reproduction now passes)